### PR TITLE
feat(cabins): add image upload support when creating a cabin

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,7 @@
 # Vite environment variables
 # Public variables (safe to commit to repo)
 # VITE_SUPABASE_URL="https://okckqyxcosgcaumsuxta.supabase.co"
+
+
+VITE_SUPABASE_URL="https://okckqyxcosgcaumsuxta.supabase.co"
+VITE_SUPABASE_IMAGE_BASE_URL="https://okckqyxcosgcaumsuxta.supabase.co/storage/v1/object/public/cabin-images/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2",
         "sonner": "^2.0.5",
-        "tailwindcss": "^4.1.8"
+        "tailwindcss": "^4.1.8",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -4605,6 +4606,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2",
     "sonner": "^2.0.5",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,10 @@
+function getEnvVar(key: string): string {
+  const value = import.meta.env[key as keyof ImportMetaEnv];
+  if (!value) throw new Error(`Missing environment variable: ${key}`);
+  return value;
+}
+
+export const SUPABASE = {
+  URL: getEnvVar("VITE_SUPABASE_URL"),
+  IMAGE_BUCKET_URL: getEnvVar("VITE_SUPABASE_IMAGE_BASE_URL"),
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,8 @@
+export * from "./config";
+
 /**
  * Application Constants
- * 
+ *
  * This file contains all application constants organized by category.
  * As the application grows, consider splitting into domain-specific files.
  */

--- a/src/features/cabins/CreateCabinForm.tsx
+++ b/src/features/cabins/CreateCabinForm.tsx
@@ -39,7 +39,7 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
 
   const onSubmit = (data: BaseCabin) => {
     console.log("Creating cabin:", data);
-    createMutation(data);
+    createMutation({ ...data, photo_url: data.photo_url?.[0] });
   };
 
   const onError = (error: unknown) => {
@@ -58,12 +58,14 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
             required
             validation={{ required: "Name is required" }}
           />
+
           <FormInput
             name="description"
             label="Cabin description"
             required
             validation={{ required: "Description is required" }}
           />
+
           <FormInput
             name="price"
             label="Cabin price"
@@ -74,6 +76,7 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
               setValueAs: (value) => (value === "" ? undefined : Number(value)),
             }}
           />
+
           <FormInput
             name="discount_amount"
             label="Cabin discount amount"
@@ -89,6 +92,7 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
               },
             }}
           />
+
           <FormInput
             name="discount_percent"
             label="Cabin discount percentage"
@@ -106,6 +110,7 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
               },
             }}
           />
+
           <FormInput
             name="capacity"
             label="Cabin capacity"
@@ -116,6 +121,7 @@ export default function CreateCabinForm({ onClose }: { onClose: () => void }) {
               min: { value: 1, message: "Capacity must be at least 1" },
             }}
           />
+
           <FormInput
             name="photo_url"
             label="Cabin image"

--- a/src/features/cabins/types.ts
+++ b/src/features/cabins/types.ts
@@ -1,5 +1,5 @@
 export type BaseCabin = {
-  photo_url?: string;
+  photo_url?: File;
   name: string;
   description: string;
   capacity: number;

--- a/src/services/api/apiCabins.ts
+++ b/src/services/api/apiCabins.ts
@@ -1,5 +1,7 @@
 import { BaseCabin } from "@/features/cabins";
 import { supabase } from "../supabase/supabase";
+import { SUPABASE } from "@/constants/config";
+import { v4 as uuidv4 } from "uuid";
 
 const TABLE_NAME = "cabins";
 const COLUMN_NAME = "id";
@@ -16,14 +18,39 @@ export async function getCabins() {
 }
 
 export async function createCabin(cabin: BaseCabin) {
+  let imageName = "";
+  let imagePath = "";
+
+  if (cabin.photo_url) {
+    const ext = cabin.photo_url.name.split(".").pop(); // e.g., "jpg"
+    imageName = `${uuidv4()}.${ext}`;
+    imagePath = `${SUPABASE.IMAGE_BUCKET_URL}${imageName}`;
+  }
+
+  // 1. Create the cabin (save the image path in DB)
   const { data, error } = await supabase
     .from("cabins")
-    .insert([cabin])
+    .insert({ ...cabin, photo_url: cabin.photo_url ? imagePath : null })
     .select();
 
   if (error) {
     console.error("Error creating cabin:", error);
     throw new Error("Failed to create cabin");
+  }
+
+  // 2. Upload the image to Supabase storage
+  if (cabin.photo_url) {
+    const { error: storageError } = await supabase.storage
+      .from("cabin-images")
+      .upload(imageName, cabin.photo_url, {
+        cacheControl: "3600",
+        upsert: false,
+      });
+
+    if (storageError) {
+      console.error("Error uploading cabin image:", storageError);
+      await deleteCabin(data[0].id); // optional rollback
+    }
   }
 
   return data;
@@ -40,5 +67,6 @@ export async function deleteCabin(id: number) {
     throw new Error("Failed to delete cabin");
   }
 
+  console.log(`Cabin deleted successfully: ${id}`);
   return data;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/*": ["./*"]
     },
+    "module": "ES2020",
     "target": "ES2020",
     "jsx": "react-jsx",
     "moduleResolution": "bundler"


### PR DESCRIPTION
Generates a unique filename for uploaded images and stores them in the 'cabin-images' bucket. Saves the full public URL in the photo_url field of the newly created cabin.