### PR TITLE
refactor(cabins): unify domain types, add API layer, and improve UX f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "lint": "eslint .",
     "preview": "vite preview",
-    "update-types": "npx supabase gen types --lang=typescript --project-id \"okckqyxcosgcaumsuxta\" > src/types/database.types.ts"
+    "update-types": "npx supabase gen types --lang=typescript --project-id \"okckqyxcosgcaumsuxta\" > src/types/supabase.types.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",

--- a/src/data/seeds/seedCabins.ts
+++ b/src/data/seeds/seedCabins.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { supabaseAdmin } from "@/services/supabase/supabaseAdmin";
-import type { CabinInsertData } from "@/types/db";
+import type { CabinInsertData } from "@/types/db-aliases";
 
 // Cabin types with realistic ranges and descriptions
 const cabinTypes = [

--- a/src/features/cabins/CabinRow.tsx
+++ b/src/features/cabins/CabinRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { CabinData } from "@/types/db";
+import type { CabinData } from "@/types/db-aliases";
 import { formatCurrency } from "@/utils/helpers";
 import { Button } from "@/components/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";

--- a/src/features/cabins/types.ts
+++ b/src/features/cabins/types.ts
@@ -1,14 +1,23 @@
-export type BaseCabin = {
+import { CabinDB, CabinInsertDB } from "@/types/db-aliases";
+
+// Used as raw return value from getCabins()
+export type CabinApiItem = CabinDB;
+export type CabinApiResponse = CabinApiItem[];
+
+/**
+ * Used in Create/Edit forms.
+ * Accepts a File object for uploading images.
+ */
+export type CabinFormData = Omit<CabinInsertDB, "photo_url"> & {
   photo_url?: File;
-  name: string;
-  description: string;
-  capacity: number;
-  price: number;
-  discount_percent: number;
-  discount_amount: number;
 };
 
-export type CabinRow = BaseCabin & {
-  id: number;
-  actions?: undefined;
+/**
+ * Used in table views or lists.https://www.f-list.net/c/Madison%20Keane
+ * Assumes all fields are already formatted for display (e.g. photo_url is a string).
+ */
+export type CabinRow = Omit<CabinApiItem, "created_at">;
+
+export type CabinTableRow = CabinRow & {
+  actions?: never;
 };

--- a/src/routes/Cabins.tsx
+++ b/src/routes/Cabins.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import CreateCabinForm from "@/features/cabins/CreateCabinForm";
 
 export default function Cabins() {
-  const [showForm, setShowForm] = useState(true);
+  const [showForm, setShowForm] = useState(false);
 
   return (
     <div className="space-y-6">

--- a/src/services/supabase/supabase.ts
+++ b/src/services/supabase/supabase.ts
@@ -1,6 +1,6 @@
 // src/services/supabase/supabase.ts
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "../../types/database.types";
+import type { Database } from "../../types/supabase.types";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;

--- a/src/services/supabase/supabaseAdmin.ts
+++ b/src/services/supabase/supabaseAdmin.ts
@@ -1,6 +1,6 @@
 // src/services/supabase/supabaseAdmin.ts
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "../../types/database.types";
+import type { Database } from "../../types/supabase.types";
 import dotenv from "dotenv";
 
 dotenv.config({ path: ".env.local" }); // or just `dotenv.config()` if you're using the default `.env`

--- a/src/types/db-aliases.ts
+++ b/src/types/db-aliases.ts
@@ -1,9 +1,12 @@
+// Aliased types built from Supabase schema, used across app for clarity.
+// Examples: CabinDB, CabinInsertDB, BookingWithGuestsDB, etc.
+
 import type {
   Tables,
   TablesInsert,
   TablesUpdate,
   Enums,
-} from "@/types/database.types";
+} from "@/types/supabase.types";
 
 // Cabin types
 export type CabinDB = Tables<"cabins">;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,1 @@
-export * from "./supabase";
+export * from "./db-aliases";

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -107,37 +107,37 @@ export type Database = {
       }
       cabins: {
         Row: {
-          capacity: number | null
+          capacity: number
           created_at: string
-          description: string | null
-          discount_amount: number | null
-          discount_percent: number | null
+          description: string
+          discount_amount: number
+          discount_percent: number
           id: number
-          name: string | null
+          name: string
           photo_url: string | null
-          price: number | null
+          price: number
         }
         Insert: {
-          capacity?: number | null
+          capacity?: number
           created_at?: string
-          description?: string | null
-          discount_amount?: number | null
-          discount_percent?: number | null
+          description?: string
+          discount_amount?: number
+          discount_percent?: number
           id?: number
-          name?: string | null
+          name: string
           photo_url?: string | null
-          price?: number | null
+          price: number
         }
         Update: {
-          capacity?: number | null
+          capacity?: number
           created_at?: string
-          description?: string | null
-          discount_amount?: number | null
-          discount_percent?: number | null
+          description?: string
+          discount_amount?: number
+          discount_percent?: number
           id?: number
-          name?: string | null
+          name?: string
           photo_url?: string | null
-          price?: number | null
+          price?: number
         }
         Relationships: []
       }


### PR DESCRIPTION
…or deletion

- Split cabin types into DB, API, form, and table-specific representations
- Added `CabinApiItem`, `CabinFormData`, and `CabinTableRow` types
- Updated `createCabin()` to accept form data and handle image upload cleanly
- Improved delete UX by disabling all delete buttons during mutation
- Added clearer success/failure toasts and contextual messages
- Adjusted Supabase schema (nullable fields, constraints) — not reflected in this commit