### PR TITLE
refactor(crud): simplify system by decoupling DataTable from CRUD con…

### DIFF
--- a/src/components/ui/table/DataTable.tsx
+++ b/src/components/ui/table/DataTable.tsx
@@ -1,12 +1,12 @@
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 
 export type DataTableProps<T extends { id: string | number }> = {
   data: T[];
-  headers?: ReadonlyArray<keyof T & string>;
   columnRenderers?: Partial<
     Record<keyof T & string, (value: T[keyof T], row: T) => ReactNode>
   >;
   labelMap?: Partial<Record<keyof T & string, string>>;
+  rowActions?: Array<(row: T) => ReactNode>;
   displayId?: boolean;
   hideRowIndex?: boolean;
 };
@@ -15,6 +15,7 @@ export default function DataTable<T extends { id: string | number }>({
   data,
   columnRenderers,
   labelMap,
+  rowActions,
   displayId = false,
   hideRowIndex = false,
 }: DataTableProps<T>) {
@@ -43,6 +44,9 @@ export default function DataTable<T extends { id: string | number }>({
                 {labelMap?.[header] ?? formatHeaderLabel(header)}
               </th>
             ))}
+            {rowActions?.length > 0 && (
+              <th className="px-4 py-2 whitespace-nowrap">Actions</th>
+            )}
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
@@ -61,6 +65,18 @@ export default function DataTable<T extends { id: string | number }>({
                     : String(item[header])}
                 </td>
               ))}
+
+              {rowActions?.length > 0 && (
+                <td className="px-4 py-2 whitespace-nowrap">
+                  <div className="flex gap-2">
+                    {rowActions.map((action, index) => (
+                      <React.Fragment key={index}>
+                        {action(item)}
+                      </React.Fragment>
+                    ))}
+                  </div>
+                </td>
+              )}
             </tr>
           ))}
         </tbody>

--- a/src/components/ui/table/index.ts
+++ b/src/components/ui/table/index.ts
@@ -1,2 +1,3 @@
 export { default as DataTable } from "./DataTable";
 export type { DataTableProps } from "./DataTable";
+export { defaultRowActions } from "./rowActions";

--- a/src/components/ui/table/rowActions.tsx
+++ b/src/components/ui/table/rowActions.tsx
@@ -1,0 +1,26 @@
+import { Button } from "../base";
+import { ReactNode } from "react";
+
+// Optional utility: group buttons with prewiring
+export function defaultRowActions<T>({
+  onEdit,
+  onDelete,
+}: {
+  onEdit?: (row: T) => void;
+  onDelete?: (row: T) => void;
+}): Array<(row: T) => ReactNode> {
+  return [
+    (row) =>
+      onEdit ? (
+        <Button variant="outline" onClick={() => onEdit(row)}>
+          Edit
+        </Button>
+      ) : null,
+    (row) =>
+      onDelete ? (
+        <Button variant="destructive" onClick={() => onDelete(row)}>
+          Delete
+        </Button>
+      ) : null,
+  ];
+}

--- a/src/layout/crud-page/types.ts
+++ b/src/layout/crud-page/types.ts
@@ -1,5 +1,4 @@
-import { FormInputProps } from "@/components/ui";
-import { ReactNode } from "react";
+import { DataTableProps, FormInputProps } from "@/components/ui";
 import { RegisterOptions, UseFormReturn } from "react-hook-form";
 
 // ============================================================
@@ -18,16 +17,13 @@ export type CrudHandlers<TForm> = {
 
 export type CrudPageProps<TForm, TTableDisplay extends { id: number }> = {
   title: string;
-  queryKey: string;
-  data: TTableDisplay[];
-
-  tableConfig: CrudTableConfig<TTableDisplay>;
+  tableProps: DataTableProps<TTableDisplay>;
   formInputs: CrudFormInput<TForm>[];
   handlers: CrudHandlers<TForm>;
 
   // Built-in behavioral hooks
-  isDeleting?: (id: number) => boolean;
-  extraActions?: (row: TTableDisplay) => ReactNode;
+  // isDeleting?: (id: number) => boolean;
+  // extraActions?: (row: TTableDisplay) => ReactNode;
 };
 
 // ============================================================
@@ -64,13 +60,12 @@ export type InternalCrudFormProps<TForm> = {
 // ========================= Table ============================
 // ============================================================
 
-export type CrudTableConfig<T> = {
-  columns: (keyof T & string)[];
-  labelMap?: Partial<Record<keyof T, string>>;
-  // columnRenderers?: Partial<
-  //   Record<keyof T & string, (value: any, row: T) => ReactNode>
-  // >;
-  columnRenderers?: {
-    [K in keyof T & string]?: (value: T[K], row: T) => ReactNode;
-  };
-};
+// export type CrudTableConfig<T> = {
+//   labelMap?: Partial<Record<keyof T, string>>;
+//   // columnRenderers?: Partial<
+//   //   Record<keyof T & string, (value: any, row: T) => ReactNode>
+//   // >;
+//   columnRenderers?: {
+//     [K in keyof T & string]?: (value: T[K], row: T) => ReactNode;
+//   };
+// };

--- a/src/routes/Cabins.tsx
+++ b/src/routes/Cabins.tsx
@@ -1,4 +1,3 @@
-import CabinForm from "@/features/cabins/CabinForm";
 import CrudPage from "@/layout/crud-page/CrudPage";
 import { useQueryClient, useQuery } from "@tanstack/react-query";
 import { getCabins } from "@/services/api/apiCabins";
@@ -15,11 +14,7 @@ import {
 import { CrudFormInput, CrudHandlers } from "@/layout/crud-page/types";
 
 export default function Cabins() {
-  const {
-    isPending,
-    data: cabins,
-    error,
-  } = useQuery({
+  const cabins = useQuery({
     queryKey: ["cabins"],
     queryFn: getCabins,
   });
@@ -54,7 +49,7 @@ export default function Cabins() {
   };
 
   const cabinsData: CabinRow[] =
-    cabins?.map(
+    cabins?.data?.map(
       (cabin): CabinRow => ({
         id: cabin.id,
         photo_url: cabin.photo_url,
@@ -67,17 +62,17 @@ export default function Cabins() {
       })
     ) || [];
 
+  const tableProps: DataTableProps<CabinRow> = {
+    data: cabinsData,
+    labelMap,
+    columnRenderers,
+  };
+
   return (
     <CrudPage
       title="Cabins"
-      queryKey="cabins"
-      data={cabinsData}
+      tableProps={tableProps}
       formInputs={formInputs}
-      tableConfig={{
-        columns: [],
-        labelMap,
-        columnRenderers,
-      }}
       handlers={crudPageHandlers}
     />
   );


### PR DESCRIPTION
…trol logic

- Removed control responsibilities (onEdit/onDelete) from DataTable
- Introduced `rowActions` prop for rendering flexible, declarative action buttons
- Added `defaultRowActions` utility for common Edit/Delete patterns
- CrudPage now owns modal and editingRow state explicitly
- Moves toward clearer boundaries: DataTable is presentational, CrudPage manages behavior