### PR TITLE
feat(crud): support edit mode with type-safe default value mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Commit message draft
 .commit-draft.md
+
+# Scratch diff file
+scratch.diff

--- a/src/layout/crud-page/CrudForm.tsx
+++ b/src/layout/crud-page/CrudForm.tsx
@@ -1,5 +1,5 @@
 import { FormInputProps, FormInput } from "@/components/ui";
-import { RegisterOptions, useForm } from "react-hook-form";
+import { DefaultValues, RegisterOptions, useForm } from "react-hook-form";
 import { FormProvider } from "react-hook-form";
 import { Button } from "@/components/ui";
 import { Form } from "@/components/ui/form";
@@ -9,10 +9,13 @@ import { CrudFormInput, InternalCrudFormProps } from "./types";
 export default function CrudForm<T>({
   formInputs = [],
   isEdit,
+  defaultValues,
   onSubmit,
   onError,
 }: InternalCrudFormProps<T>) {
-  const methods = useForm<T>();
+  const methods = useForm<T>({
+    defaultValues: defaultValues as DefaultValues<T>,
+  });
 
   return (
     <div className="bg-[var(--color-bg-base)] rounded-lg border border-[--color-border] p-6 shadow-sm transition-shadow hover:shadow-md max-w-2xl mx-auto w-full">

--- a/src/layout/crud-page/types.ts
+++ b/src/layout/crud-page/types.ts
@@ -8,8 +8,12 @@ import { RegisterOptions, UseFormReturn } from "react-hook-form";
 export type CrudMode = "create" | "edit";
 
 export type CrudHandlers<TForm> = {
-  onCreate?: (data: TForm) => void;
-  onUpdate?: (id: number, data: TForm) => void;
+  onCreate?: (data: TForm, options?: { onSuccess?: () => void }) => void;
+  onUpdate?: (
+    id: number,
+    data: TForm,
+    options?: { onSuccess?: () => void }
+  ) => void;
   onDelete?: (id: number) => void;
   onSubmit?: (data: TForm) => void;
   onError?: (error: unknown) => void;
@@ -19,7 +23,10 @@ export type CrudPageProps<TForm, TTableDisplay extends { id: number }> = {
   title: string;
   tableProps: DataTableProps<TTableDisplay>;
   formInputs: CrudFormInput<TForm>[];
+  defaultValuesMapper?: (row: TTableDisplay) => Partial<TForm>;
   handlers: CrudHandlers<TForm>;
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
 
   // Built-in behavioral hooks
   // isDeleting?: (id: number) => boolean;
@@ -49,6 +56,7 @@ export type CrudFormInput<TForm> = Omit<
  * Used by CrudPage to render the form UI.
  */
 export type InternalCrudFormProps<TForm> = {
+  defaultValues?: Partial<TForm>;
   formInputs: CrudFormInput<TForm>[];
   isEdit?: boolean;
   title?: string;

--- a/src/routes/Cabins.tsx
+++ b/src/routes/Cabins.tsx
@@ -12,8 +12,12 @@ import {
   deleteCabin,
 } from "@/services/api/apiCabins";
 import { CrudFormInput, CrudHandlers } from "@/layout/crud-page/types";
+import { useRef } from "react";
+import { CrudPageHandle } from "@/layout/crud-page/CrudPage";
 
 export default function Cabins() {
+  const ref = useRef<CrudPageHandle<CabinRow>>(null);
+
   const cabins = useQuery({
     queryKey: ["cabins"],
     queryFn: getCabins,
@@ -27,6 +31,7 @@ export default function Cabins() {
     deleteFn: deleteCabin,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cabins"] });
+      ref.current?.closeModal();
     },
   });
 
@@ -74,6 +79,8 @@ export default function Cabins() {
       tableProps={tableProps}
       formInputs={formInputs}
       handlers={crudPageHandlers}
+      defaultValuesMapper={defaultValuesMapper}
+      ref={ref}
     />
   );
 }
@@ -123,14 +130,12 @@ const formInputs: CrudFormInput<CabinFormData>[] = [
   {
     name: "discount_amount",
     label: "Cabin discount amount",
-    required: true,
     validation: (methods) => ({
-      required: "Discount amount is required",
       min: { value: 0, message: "Discount amount cannot be negative" },
       setValueAs: (value) => (value === "" ? undefined : Number(value)),
       validate: (value) => {
         const price = methods.getValues("price");
-        if (value <= price) return true;
+        if (value <= price || value === undefined) return true;
         return "Discount amount cannot exceed price";
       },
     }),
@@ -138,10 +143,8 @@ const formInputs: CrudFormInput<CabinFormData>[] = [
   {
     name: "discount_percent",
     label: "Cabin discount percentage",
-    required: true,
     validation: {
       setValueAs: (value) => (value === "" ? undefined : Number(value)),
-      required: "Discount percentage is required",
       min: {
         value: 0,
         message: "Discount percentage cannot be negative",
@@ -169,3 +172,13 @@ const formInputs: CrudFormInput<CabinFormData>[] = [
     validation: {},
   },
 ];
+
+const defaultValuesMapper = (row: CabinRow) => ({
+  name: row.name,
+  description: row.description,
+  price: row.price,
+  discount_amount: row.discount_amount,
+  discount_percent: row.discount_percent,
+  capacity: row.capacity,
+  photo_url: undefined,
+});

--- a/src/services/api/apiCabins.ts
+++ b/src/services/api/apiCabins.ts
@@ -21,21 +21,76 @@ export async function getCabins(): Promise<CabinApiResponse> {
   return data ?? [];
 }
 
+// export async function createCabin(cabin: CabinFormData) {
+//   console.log("DATA RECEIVED AT API LAYER: (apiCabins: )", cabin);
+
+//   let imageName = "";
+//   let imagePath = "";
+
+//   const { photo_url, ...formData } = cabin;
+
+//   if (photo_url) {
+//     const ext = photo_url.name.split(".").pop(); // e.g., "jpg"
+//     imageName = `${uuidv4()}.${ext}`;
+//     imagePath = `${SUPABASE.IMAGE_BUCKET_URL}${imageName}`;
+//   }
+
+//   const cabinInsertPayload: CabinInsertPayload = {
+//     ...formData,
+//     photo_url: imagePath,
+//   };
+
+//   // 1. Create the cabin (save the image path in DB)
+//   const { data, error } = await supabase
+//     .from("cabins")
+//     .insert(cabinInsertPayload)
+//     .select()
+//     .single();
+
+//   if (error) {
+//     console.error("Error creating cabin:", error);
+//     throw new Error("Failed to create cabin");
+//   }
+
+//   // 2. Upload the image to Supabase storage
+//   if (photo_url) {
+//     const { error: storageError } = await supabase.storage
+//       .from("cabin-images")
+//       .upload(imageName, photo_url, {
+//         cacheControl: "3600",
+//         upsert: false,
+//       });
+
+//     if (storageError) {
+//       console.error("Error uploading cabin image:", storageError);
+//       await deleteCabin(data.id); // optional rollback
+//     }
+//   }
+
+//   return data;
+// }
+
 export async function createCabin(cabin: CabinFormData) {
+  console.log("DATA RECEIVED AT API LAYER: (apiCabins: createCabin)", cabin);
+
   let imageName = "";
   let imagePath = "";
 
-  const { photo_url, ...formData } = cabin;
+  // Handle file extraction safely
+  const file =
+    cabin.photo_url instanceof FileList
+      ? cabin.photo_url[0] ?? null
+      : (cabin.photo_url as File | null);
 
-  if (photo_url) {
-    const ext = photo_url.name.split(".").pop(); // e.g., "jpg"
+  if (file) {
+    const ext = file.name.split(".").pop(); // e.g., "jpg"
     imageName = `${uuidv4()}.${ext}`;
     imagePath = `${SUPABASE.IMAGE_BUCKET_URL}${imageName}`;
   }
 
   const cabinInsertPayload: CabinInsertPayload = {
-    ...formData,
-    photo_url: imagePath,
+    ...cabin,
+    photo_url: file ? imagePath : null,
   };
 
   // 1. Create the cabin (save the image path in DB)
@@ -51,17 +106,17 @@ export async function createCabin(cabin: CabinFormData) {
   }
 
   // 2. Upload the image to Supabase storage
-  if (photo_url) {
+  if (file) {
     const { error: storageError } = await supabase.storage
       .from("cabin-images")
-      .upload(imageName, photo_url, {
+      .upload(imageName, file, {
         cacheControl: "3600",
         upsert: false,
       });
 
     if (storageError) {
       console.error("Error uploading cabin image:", storageError);
-      await deleteCabin(data.id); // optional rollback
+      await deleteCabin(data.id); // optional rollback if upload fails
     }
   }
 


### PR DESCRIPTION
- Add `defaultValuesMapper` to CrudPageProps to decouple table and form types
- Implement `useImperativeHandle` to expose modal controls via parent ref
- Populate default form values in edit mode using mapped table row
- Refactor `onCreate` and `onUpdate` handlers to accept onSuccess callback
- Update Cabin page to use new API, provide default value mapping function
- Minor cleanup of validation rules and optional props for clarity